### PR TITLE
CR-2152 #time 1h Add method that allows for specific queries

### DIFF
--- a/Model/Behavior/ElasticSearchIndexableBehavior.php
+++ b/Model/Behavior/ElasticSearchIndexableBehavior.php
@@ -793,7 +793,7 @@ class ElasticSearchIndexableBehavior extends ModelBehavior {
 
         $results = $this->_esSearchRawResults($Model, $query, $additionalOptions);
 
-        return !empty($results) ? true : false;
+        return !empty($results);
 
     }
 

--- a/Model/Behavior/ElasticSearchIndexableBehavior.php
+++ b/Model/Behavior/ElasticSearchIndexableBehavior.php
@@ -776,4 +776,25 @@ class ElasticSearchIndexableBehavior extends ModelBehavior {
 		return $query;
 	}
 
+    /**
+     * Method used to pass in a query and check if the ES term exists based on that criteria
+     * Allows for specific matches on a keys, eg.
+     * { "_source": true, "query" : { "term" : { "association_key" : "160524"  } } }
+     *
+     * @param Model $Model
+     * @param string $query
+     * @return bool
+     */
+    public function hasEsTerm(Model $Model, $query = '') {
+
+        $additionalOptions = array(
+            'size' => 1
+        );
+
+        $results = $this->_esSearchRawResults($Model, $query, $additionalOptions);
+
+        return !empty($results) ? true : false;
+
+    }
+
 }


### PR DESCRIPTION
Method allows for specific queries against a desired _source key
instead of using the default fuzzy matching. For example
{"_source":true, "query": {"term" : {"association_key" : "2"}}} as
a query would only try to match on an association_key of 2 instead
of any association_key that contains a 2 within it.